### PR TITLE
Add update channels command to force channel list refresh

### DIFF
--- a/src/bolt/events/RegisterEventAppMention.ts
+++ b/src/bolt/events/RegisterEventAppMention.ts
@@ -1,3 +1,4 @@
+import {channelList, updateChannelInfo} from '../utils';
 import {
     getGroupToMentionInChannel,
     getRepositoryNumberOfApprovals,
@@ -24,15 +25,23 @@ export default function registerEventAppMention (app: App): void {
                 thread_ts: thread_ts ?? ts,
             });
         } else {
-            const regExCmd = /\s+set\s+([^\s]+)\s+([^\s]+)(?:\s+)?(\d+)?/i;
+            const regExCmd = /\s+(set|update)\s+([^\s]+)(?:\s+([^\s]+)(?:\s+)?(\d+)?)?/i;
             const result = regExCmd.exec(text);
 
             if (!result) {
                 return;
             }
 
-            logDebug('set command', result);
+            result.shift();
+            logDebug('set|update command', result);
             switch (result[1]) {
+                case 'channels':
+                    await updateChannelInfo();
+                    await say({
+                        text: `Channel list updated: ${JSON.stringify(channelList)}`,
+                        thread_ts: thread_ts ?? ts,
+                    });
+                    break;
                 case 'review':
                     await setRepositoryNumberOfReviews(result[2], parseInt(result[3]));
                     await say({

--- a/src/bolt/events/RegisterEventMemberJoinedChannel.ts
+++ b/src/bolt/events/RegisterEventMemberJoinedChannel.ts
@@ -12,6 +12,6 @@ export default function registerEventMemberJoinedChannel (app: App): void {
         if (await getBotUserId() !== event.user) {
             return;
         }
-        updateChannelInfo();
+        await updateChannelInfo();
     });
 }

--- a/src/bolt/utils.ts
+++ b/src/bolt/utils.ts
@@ -104,13 +104,14 @@ export async function getChannels (): Promise<ChannelInfo[]> {
 
 export const channelMaps: {[index: string]: ChannelInfo | null} = {};
 export let channelList: ChannelInfo[] = [];
-export function updateChannelInfo (): void {
-    void getChannels().then((result) => {
+export async function updateChannelInfo (): Promise<ChannelInfo[]> {
+    await getChannels().then((result) => {
         channelList = result;
         result.forEach((channelInfo) => {
             channelMaps[channelInfo.id] = channelMaps[channelInfo.name] = channelInfo;
         });
     });
+    return channelList;
 }
 
 export async function getReactionData (event: ReactionAddedEvent | ReactionRemovedEvent): Promise<ReactionData | null> {
@@ -460,5 +461,5 @@ export async function sentHomePageCodeReviewList ({slackUserId, codeReviewStatus
 export function registerSlackBotApp (app: App): void {
     slackBotApp = app;
     registerSchedule();
-    updateChannelInfo();
+    void updateChannelInfo();
 }


### PR DESCRIPTION
When the bot is invited and join a channel, it auto refresh the available channel list.
This PR would add a new command to force the app to update the channel list when necessary.