### PR TITLE
Fix various bugs: set slack-github-id, slack/web app login

### DIFF
--- a/src/bolt/events/RegisterEventAppMention.ts
+++ b/src/bolt/events/RegisterEventAppMention.ts
@@ -1,4 +1,8 @@
-import {channelList, updateChannelInfo} from '../utils';
+import {
+    channelList,
+    getUserInfo,
+    updateChannelInfo
+} from '../utils';
 import {
     getDataRetentionInMonth,
     getDefaultReviewChannel,
@@ -102,36 +106,42 @@ export default function registerEventAppMention (app: App): void {
                     });
                     break;
                 case 'slack-github-id': // @pmc_code_review_bot set slack-github-id <slack-id> <github-id>
+                {
                     if (!result[2] || !result[3]) {
                         return;
                     }
+                    const inputSlackUserId = result[2];
+                    const inputGithubUserId = result[3];
 
-                    await prisma.user.findFirst({
+                    const userInfo = await getUserInfo(inputSlackUserId);
+
+                    if (!userInfo.displayName) {
+                        console.log(`Cannot locate slack user id ${inputSlackUserId}`);
+                        void say({
+                            text: `Cannot locate slack user id ${inputSlackUserId}`,
+                            thread_ts: thread_ts ?? ts,
+                        });
+
+                        return;
+                    }
+
+                    await prisma.user.update({
                         where: {
-                            slackUserId: result[2],
-                        }
-                    }).then((user) => {
-                        if (!user) {
-                            return;
-                        }
-
-                        void prisma.user.update({
-                            where: {
-                                id: user.id,
-                            },
-                            data: {
-                                githubId: result[3],
-                            },
-                        }).then((updatedUser) => {
-                            console.log('updated', updatedUser);
-                            void say({
-                                text: `Set *${updatedUser.displayName}*'s github login to *${updatedUser.githubId ?? ''}*`,
-                                thread_ts: thread_ts ?? ts,
-                            });
-                        }).catch(logError);
+                            id: (await User.findOrCreate(inputSlackUserId)).id
+                        },
+                        data: {
+                            githubId: inputGithubUserId,
+                        },
+                    }).then((updatedUser) => {
+                        console.log('updated', updatedUser);
+                        void say({
+                            text: `Set *${updatedUser.displayName}*'s github login to *${updatedUser.githubId ?? ''}*`,
+                            thread_ts: thread_ts ?? ts,
+                        });
                     }).catch(logError);
 
                     break;
+                }
                 case 'my-github-id': // @pmc_code_review_bot set my-github-id <github-id>
                     if (!slackUserId) {
                         return;

--- a/src/bolt/utils.ts
+++ b/src/bolt/utils.ts
@@ -494,52 +494,60 @@ export async function sentHomePageCodeReviewList ({slackUserId, codeReviewStatus
         value: 'mine',
         action_id: 'mine',
     };
-    let buttonWebLogin;
 
     // Retrieve the user session info from user record in db.
-    const user = await prisma.user.findFirst({
+    let user = await prisma.user.findFirst({
         where: {
             slackUserId,
         }
     });
 
+    if (!user) {
+        const userInfo = await getUserInfo(slackUserId);
+
+        user = await prisma.user.create({
+            data: {
+                email: userInfo.email,
+                displayName: userInfo.displayName,
+                slackUserId,
+            }
+        });
+    }
+
     const session = (user?.session ?? {filterChannel: '', filterStatus: ''}) as {filterChannel?: string; filterStatus?: string};
     const filterChannel = slackChannelId || session.filterChannel || 'all'; // eslint-disable-line @typescript-eslint/prefer-nullish-coalescing
     const filterStatus = codeReviewStatus ?? session.filterStatus;
 
-    if (user) {
-        // If the request filter changed, save them to the session.
-        if (filterChannel !== session.filterChannel || filterStatus !== session.filterStatus) {
-            Object.assign(session, {filterChannel, filterStatus});
-            await prisma.user.update({
-                where: {
-                    id: user.id,
-                },
-                data: {
-                    session,
-                }
-            });
-        }
-
-        let authToken = getSessionValueByKey(user, 'token') as string | undefined;
-
-        if (!authToken) {
-            authToken = await generateAuthToken({id: user.id});
-        }
-
-        buttonWebLogin = {
-            type: 'button',
-            text: {
-                type: 'plain_text',
-                text: ':slack: Sign In To Web Version',
-                emoji: true
+    // If the request filter changed, save them to the session.
+    if (filterChannel !== session.filterChannel || filterStatus !== session.filterStatus) {
+        Object.assign(session, {filterChannel, filterStatus});
+        await prisma.user.update({
+            where: {
+                id: user.id,
             },
-            value: authToken,
-            action_id: 'weblogin',
-            url: `${APP_BASE_URL}/auth/slack/token/${user.id}/${authToken}`,
-        };
-
+            data: {
+                session,
+            }
+        });
     }
+
+    let authToken = getSessionValueByKey(user, 'token') as string | undefined;
+
+    if (!authToken) {
+        authToken = await generateAuthToken({id: user.id});
+    }
+
+    const buttonWebLogin = {
+        type: 'button',
+        text: {
+            type: 'plain_text',
+            text: ':slack: Sign In To Web Version',
+            emoji: true
+        },
+        value: authToken,
+        action_id: 'weblogin',
+        url: `${APP_BASE_URL}/auth/slack/token/${user.id}/${authToken}`,
+    };
 
     const channels = await getChannels();
     const options = [
@@ -579,9 +587,7 @@ export async function sentHomePageCodeReviewList ({slackUserId, codeReviewStatus
         buttonMyReviews,
     ];
 
-    if (buttonWebLogin) {
-        buttons.push(buttonWebLogin);
-    }
+    buttons.push(buttonWebLogin);
 
     let blocks: (Block | KnownBlock)[] = [
         {

--- a/src/express/routes/api.ts
+++ b/src/express/routes/api.ts
@@ -15,11 +15,12 @@ import sessionController from '../controllers/api/session';
 
 const apiRouter = express.Router();
 
+// These routes don't need to be authenticated.
 apiRouter.use('/', handleWebhooks);
-
-// All routes from here on are required to authenticate
-apiRouter.use('/', enforceAuthentication);
 apiRouter.get('/session', sessionController);
+
+// All routes from here on are required to be authenticated.
+apiRouter.use('/', enforceAuthentication);
 apiRouter.get('/profile', profileController);
 apiRouter.get('/action/:action/:value', actionController);
 apiRouter.post('/action/save/:value', saveController);


### PR DESCRIPTION
* Remove authentication required for /api/session route.
   * Provide web login link with app & team id.  Fix the login link for external workspace invited slack user.
* Auto create user profile if slack id is valid for set slack-github-id
* Auto create user profile and display `Sign In To Web Version` button on slack bot homepage.
   * Fix issue with external user unable to login to code review web site.